### PR TITLE
Inference id warning

### DIFF
--- a/init_params.py
+++ b/init_params.py
@@ -1,7 +1,8 @@
-import os
 import argparse
-from uuid import uuid4
+import os
 import sys
+import warnings
+from uuid import uuid4
 
 
 def init_main_args():
@@ -184,7 +185,15 @@ def parse_main_args(args):
     if args.id:
         params['id'] = args.id[0]
     else:
+        if not params["train"]:
+            warnings.warn(
+                "--id parameter is not set when running inference."
+                "If --train is not set, you might want to provide the"
+                "experiment id of your best training experiment run,"
+                " E.g. `--id 2310136305`"
+                )
         params['id'] = str(uuid4().time_low)
+
     print(f"\nExperiment ID: {params['id']}")
     # Creating experiments results folder with the format
     # {experiment_module_name}_{logs_type}_{id}

--- a/preprocess/open_source_logs.py
+++ b/preprocess/open_source_logs.py
@@ -1,29 +1,31 @@
-from .registry import register
-from .utils import remove_parameters
-from tqdm import tqdm
 import os
 from multiprocessing import Pool
+
+from tqdm import tqdm
+
+from .registry import register
+from .utils import remove_parameters
 
 
 def process_line(line):
     label = line[0].strip()
-    msg = ' '.join(line[1].strip().split()[1:])
+    msg = " ".join(line[1].strip().split()[1:])
     msg = remove_parameters(msg)
     if msg:
-        msg = ' '.join((label, msg))
-        msg = ''.join((msg, '\n'))
+        msg = " ".join((label, msg))
+        msg = "".join((msg, "\n"))
         return msg
-    return ''
+    return ""
 
 
 def process_open_source(input_source, output):
-    with open(output, "w", encoding='latin-1') as f:
+    with open(output, "w", encoding="latin-1") as f:
         gtruth = os.path.join(input_source, "groundtruth.seq")
         rawlog = os.path.join(input_source, "rawlog.log")
-        with open(gtruth, 'r', encoding='latin-1') as IN:
+        with open(gtruth, "r", encoding="latin-1") as IN:
             line_count = sum(1 for line in IN)
-        with open(gtruth, 'r', encoding='latin-1') as in_gtruth:
-            with open(rawlog, 'r', encoding='latin-1') as in_log:
+        with open(gtruth, "r", encoding="latin-1") as in_gtruth:
+            with open(rawlog, "r", encoding="latin-1") as in_log:
                 IN = zip(in_gtruth, in_log)
                 with Pool() as pool:
                     results = pool.imap(process_line, IN, chunksize=10000)
@@ -31,24 +33,22 @@ def process_open_source(input_source, output):
 
 
 open_source_datasets = [
-    'open_Apache',
-    'open_bgl',
-    'open_hadoop',
-    'open_hdfs',
-    'open_hpc',
-    'open_proxifier',
-    'open_zookeeper',
+    "open_Apache",
+    "open_bgl",
+    "open_hadoop",
+    "open_hdfs",
+    "open_hpc",
+    "open_proxifier",
+    "open_zookeeper",
 ]
 for dataset in open_source_datasets:
+
     @register(dataset)
     def preprocess_dataset(params):
         """
         Runs open source logs preprocessing executor.
         """
-        input_source = os.path.join(
-            params['raw_logs'],
-            dataset.split('_')[-1]
-        )
-        output = params['logs']
-        params['healthy_label'] = 'NA'
+        input_source = params["raw_logs"]
+        output = params["logs"]
+        params["healthy_label"] = "NA"
         process_open_source(input_source, output)


### PR DESCRIPTION
* Adds a warning when a user is trying to run inference without manually specifying an experiment id.
* Fix an issue when creating the preprocessing functions for each of the open source datasets that already come with the repo.